### PR TITLE
Add Celery job server with scheduled task

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,10 +42,27 @@ services:
     volumes:
       - ./api/src:/app/src
 
-  jobs:
+  jobs-worker:
     build:
       context: ./jobs
       dockerfile: Dockerfile
+    command: celery -A src.celery_app worker --loglevel=info
+    environment:
+      DATABASE_URL: postgresql://openhedgefund:localdev@db:5432/openhedgefund
+      REDIS_URL: redis://redis:6379/0
+    depends_on:
+      db:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    volumes:
+      - ./jobs/src:/app/src
+
+  jobs-beat:
+    build:
+      context: ./jobs
+      dockerfile: Dockerfile
+    command: celery -A src.celery_app beat --loglevel=info
     environment:
       DATABASE_URL: postgresql://openhedgefund:localdev@db:5432/openhedgefund
       REDIS_URL: redis://redis:6379/0

--- a/jobs/Dockerfile
+++ b/jobs/Dockerfile
@@ -6,5 +6,3 @@ COPY pyproject.toml .
 RUN pip install --no-cache-dir .
 
 COPY . .
-
-CMD ["python", "-m", "src.main"]

--- a/jobs/pyproject.toml
+++ b/jobs/pyproject.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 description = "OpenHedgeFund Job Server"
 requires-python = ">=3.12"
 dependencies = [
+    "celery[redis]>=5.4",
     "sqlalchemy>=2.0",
     "psycopg2-binary>=2.9",
     "redis>=5.0",

--- a/jobs/src/celery_app.py
+++ b/jobs/src/celery_app.py
@@ -1,0 +1,24 @@
+import os
+
+from celery import Celery
+from celery.schedules import crontab
+
+REDIS_URL = os.environ.get("REDIS_URL", "redis://localhost:6379/0")
+
+app = Celery("openhedgefund", broker=REDIS_URL, backend=REDIS_URL)
+
+app.conf.update(
+    task_serializer="json",
+    accept_content=["json"],
+    result_serializer="json",
+    timezone="UTC",
+    enable_utc=True,
+    beat_schedule={
+        "hello-every-5-minutes": {
+            "task": "src.tasks.hello",
+            "schedule": crontab(minute="*/5"),
+        },
+    },
+)
+
+app.autodiscover_tasks(["src"])

--- a/jobs/src/main.py
+++ b/jobs/src/main.py
@@ -1,16 +1,2 @@
-import time
-import logging
-
-logging.basicConfig(level=logging.INFO)
-logger = logging.getLogger(__name__)
-
-
-def main():
-    logger.info("OpenHedgeFund job server starting...")
-    while True:
-        # TODO: Poll for jobs from Redis queue
-        time.sleep(1)
-
-
-if __name__ == "__main__":
-    main()
+from src.celery_app import app  # noqa: F401
+import src.tasks  # noqa: F401

--- a/jobs/src/tasks.py
+++ b/jobs/src/tasks.py
@@ -1,0 +1,6 @@
+from src.celery_app import app
+
+
+@app.task
+def hello():
+    print("Hello")


### PR DESCRIPTION
## Summary
- Replace the manual polling loop in `jobs/` with **Celery** (worker + beat)
- Add a sample `hello` task scheduled to print `"Hello"` every 5 minutes via cron
- Split Docker Compose `jobs` service into `jobs-worker` and `jobs-beat` containers
- Add `celery[redis]` dependency to `pyproject.toml`

## Test plan
- [ ] Run `docker compose up` and verify `jobs-worker` and `jobs-beat` containers start
- [ ] Check `jobs-worker` logs for the `"Hello"` print every 5 minutes
- [ ] Verify Redis broker connection is healthy

🤖 Generated with [Claude Code](https://claude.com/claude-code)