### PR TITLE
Fix file input not cleared after successful upload

### DIFF
--- a/ui/src/app/import-data/page.tsx
+++ b/ui/src/app/import-data/page.tsx
@@ -168,6 +168,7 @@ function ImportDataContent() {
       const selectedConfig = files.find((f) => String(f.id) === selectedFileId);
       await fileImportApi.uploadFile(selectedFile, fileId, selectedConfig?.type);
       setUploadSuccess("File uploaded successfully.");
+      // Clear file input so re-uploading the same filename triggers onChange
       setSelectedFile(null);
       if (fileInputRef.current) fileInputRef.current.value = "";
       await loadImports();


### PR DESCRIPTION
Closes #39 - Clear fileInputRef and selectedFile state after successful upload so re-uploading the same filename triggers the browser onChange event.