### PR TITLE
Configure jobs DB connection pool for multiple Celery workers

### DIFF
--- a/jobs/src/database.py
+++ b/jobs/src/database.py
@@ -7,7 +7,11 @@ DATABASE_URL = os.environ.get(
     "DATABASE_URL", "postgresql://openhedgefund:localdev@localhost:5432/openhedgefund"
 )
 
-engine = create_engine(DATABASE_URL)
+engine = create_engine(
+    DATABASE_URL,
+    pool_size=20,
+    max_overflow=10,
+)
 SessionLocal = sessionmaker(bind=engine)
 
 


### PR DESCRIPTION
Closes #34 - Set pool_size=20 and max_overflow=10 on the SQLAlchemy engine in jobs/src/database.py