### PR TITLE
Enable task_acks_late for Celery crash resilience

### DIFF
--- a/jobs/src/celery_app.py
+++ b/jobs/src/celery_app.py
@@ -13,6 +13,8 @@ app.conf.update(
     result_serializer="json",
     timezone="UTC",
     enable_utc=True,
+    task_acks_late=True,
+    task_reject_on_worker_lost=True,
     # This is a temporary cron job to make sure jobs work with celery.
     # Also the job calls an open source api.
     # TODO: update this job to use a commercial pricing source.


### PR DESCRIPTION
Adds task_acks_late=True and task_reject_on_worker_lost=True to Celery config for crash resilience. Closes #32.