### PR TITLE
Prevent duplicate FX rate fetch on multi-worker restart

### DIFF
--- a/jobs/src/celery_app.py
+++ b/jobs/src/celery_app.py
@@ -1,7 +1,10 @@
+import logging
 import os
+from datetime import datetime, timedelta, timezone
 
 from celery import Celery
 from celery.schedules import crontab
+from sqlalchemy import text
 
 REDIS_URL = os.environ.get("REDIS_URL", "redis://localhost:6379/0")
 
@@ -27,8 +30,50 @@ app.conf.update(
 
 app.autodiscover_tasks(["src"])
 
+logger = logging.getLogger(__name__)
+
+SKIP_WINDOW = timedelta(hours=4)
+
 
 @app.on_after_finalize.connect
 def run_missed_jobs(sender, **kwargs):
-    """Trigger jobs that may have been missed while the worker was down."""
-    sender.send_task("src.tasks.fetch_fx_rates")
+    """Trigger jobs that may have been missed while the worker was down.
+
+    Checks last_run_at in the jobs table to avoid duplicate firing when
+    multiple workers restart simultaneously.
+    """
+    from src.database import get_session
+
+    task_name = "src.tasks.fetch_fx_rates"
+    try:
+        session = get_session()
+        try:
+            row = session.execute(
+                text("""
+                    SELECT MAX(last_run_at) AS last_run
+                    FROM jobs
+                    WHERE task_name = :task_name
+                """),
+                {"task_name": task_name},
+            ).fetchone()
+
+            if row and row.last_run:
+                last_run = row.last_run
+                if last_run.tzinfo is None:
+                    last_run = last_run.replace(tzinfo=timezone.utc)
+                cutoff = datetime.now(timezone.utc) - SKIP_WINDOW
+                if last_run > cutoff:
+                    logger.info(
+                        "Skipping %s on startup — last ran at %s",
+                        task_name,
+                        last_run.isoformat(),
+                    )
+                    return
+        finally:
+            session.close()
+    except Exception:
+        logger.warning(
+            "Could not check last_run_at for %s, firing anyway", task_name, exc_info=True
+        )
+
+    sender.send_task(task_name)


### PR DESCRIPTION
Checks last_run_at in the jobs table before firing fetch_fx_rates on worker startup. If the job ran within the last 4 hours, skips the duplicate fire. Falls back to firing the task if the DB check fails. Closes #29