### PR TITLE
Optimize FX rate fetcher with bulk SQL upsert

### DIFF
--- a/jobs/src/jobs/fx_rate_fetcher.py
+++ b/jobs/src/jobs/fx_rate_fetcher.py
@@ -27,14 +27,17 @@ def _fetch_rates() -> dict:
     raise RuntimeError("Failed to fetch FX rates from all sources")
 
 
-def _upsert_rates_for_tenant(
-    session, tenant_id: str, rate_date: str, rates: dict[str, float],
-    ccy_lookup: dict[str, int], usd_id: int,
-) -> dict:
-    """Upsert FX rates for a single tenant. Returns per-tenant summary."""
-    now = datetime.now(timezone.utc)
-    inserted = 0
-    updated = 0
+def _prepare_rate_rows(
+    rates: dict[str, float],
+    ccy_lookup: dict[str, int],
+    usd_id: int,
+) -> tuple[list[dict], int]:
+    """Filter and compute rate rows from API data.
+
+    Returns:
+        Tuple of (list of rate param dicts, skipped count).
+    """
+    rows = []
     skipped = 0
 
     for code, rate_value in rates.items():
@@ -47,43 +50,91 @@ def _upsert_rates_for_tenant(
 
         direct = Decimal(str(rate_value))
         indirect = Decimal("1") / direct if direct else Decimal("0")
-
-        result = session.execute(
-            text("""
-                INSERT INTO fx_rates
-                    (rate_date, ref_currency_id, currency_id, direct, indirect,
-                     last_modified_by, last_modified_on, tenant_id)
-                VALUES
-                    (:rate_date, :ref_currency_id, :currency_id, :direct, :indirect,
-                     :last_modified_by, :last_modified_on, :tenant_id)
-                ON CONFLICT (rate_date, ref_currency_id, currency_id, tenant_id)
-                DO UPDATE SET
-                    direct = EXCLUDED.direct,
-                    indirect = EXCLUDED.indirect,
-                    last_modified_by = EXCLUDED.last_modified_by,
-                    last_modified_on = EXCLUDED.last_modified_on,
-                    updated_at = now()
-                RETURNING (xmax = 0) AS was_insert
-            """),
+        rows.append(
             {
-                "rate_date": rate_date,
-                "ref_currency_id": usd_id,
                 "currency_id": currency_id,
                 "direct": direct,
                 "indirect": indirect,
-                "last_modified_by": "system",
-                "last_modified_on": now,
-                "tenant_id": tenant_id,
-            },
+            }
         )
 
-        row = result.fetchone()
-        if row.was_insert:
-            inserted += 1
-        else:
-            updated += 1
+    return rows, skipped
 
-    return {"tenant_id": tenant_id, "inserted": inserted, "updated": updated, "skipped": skipped}
+
+def _bulk_upsert(
+    session,
+    rate_date: str,
+    usd_id: int,
+    rate_rows: list[dict],
+) -> dict:
+    """Bulk upsert FX rates for all tenants using a staging temp table.
+
+    Returns:
+        dict with total inserted and updated counts per tenant.
+    """
+    now = datetime.now(timezone.utc)
+
+    # Create a temp table to stage the rate data
+    session.execute(
+        text("""
+        CREATE TEMP TABLE _fx_staging (
+            currency_id BIGINT,
+            direct NUMERIC(28, 12),
+            indirect NUMERIC(28, 12)
+        ) ON COMMIT DROP
+    """)
+    )
+
+    # Bulk insert all rates into staging
+    session.execute(
+        text("""
+            INSERT INTO _fx_staging (currency_id, direct, indirect)
+            VALUES (:currency_id, :direct, :indirect)
+        """),
+        rate_rows,
+    )
+
+    # Cross-join staging with tenants and upsert into fx_rates in one query.
+    # RETURNING tells us per-tenant insert vs update counts.
+    result = session.execute(
+        text("""
+            INSERT INTO fx_rates
+                (rate_date, ref_currency_id, currency_id, direct, indirect,
+                 last_modified_by, last_modified_on, tenant_id)
+            SELECT
+                :rate_date, :ref_currency_id, s.currency_id, s.direct, s.indirect,
+                :last_modified_by, :last_modified_on, t.id
+            FROM _fx_staging s
+            CROSS JOIN tenants t
+            ON CONFLICT (rate_date, ref_currency_id, currency_id, tenant_id)
+            DO UPDATE SET
+                direct = EXCLUDED.direct,
+                indirect = EXCLUDED.indirect,
+                last_modified_by = EXCLUDED.last_modified_by,
+                last_modified_on = EXCLUDED.last_modified_on,
+                updated_at = now()
+            RETURNING tenant_id, (xmax = 0) AS was_insert
+        """),
+        {
+            "rate_date": rate_date,
+            "ref_currency_id": usd_id,
+            "last_modified_by": "system",
+            "last_modified_on": now,
+        },
+    )
+
+    # Aggregate insert/update counts per tenant
+    tenant_counts: dict[str, dict[str, int]] = {}
+    for row in result.fetchall():
+        tid = str(row.tenant_id)
+        if tid not in tenant_counts:
+            tenant_counts[tid] = {"inserted": 0, "updated": 0}
+        if row.was_insert:
+            tenant_counts[tid]["inserted"] += 1
+        else:
+            tenant_counts[tid]["updated"] += 1
+
+    return tenant_counts
 
 
 def fetch_and_upsert() -> dict:
@@ -112,15 +163,29 @@ def fetch_and_upsert() -> dict:
         if not tenant_rows:
             raise RuntimeError("No tenants found in tenants table")
 
-        tenant_summaries = []
-        for tenant_row in tenant_rows:
-            summary = _upsert_rates_for_tenant(
-                session, str(tenant_row.id), rate_date, rates, ccy_lookup, usd_id,
-            )
-            tenant_summaries.append(summary)
-            logger.info("FX rate upsert for tenant %s: %s", tenant_row.id, summary)
+        # Prepare rate rows (filter by known currencies, compute direct/indirect)
+        rate_rows, skipped = _prepare_rate_rows(rates, ccy_lookup, usd_id)
+
+        if rate_rows:
+            tenant_counts = _bulk_upsert(session, rate_date, usd_id, rate_rows)
+        else:
+            tenant_counts = {}
 
         session.commit()
+
+        # Build per-tenant summaries
+        tenant_summaries = []
+        for tenant_row in tenant_rows:
+            tid = str(tenant_row.id)
+            counts = tenant_counts.get(tid, {"inserted": 0, "updated": 0})
+            summary = {
+                "tenant_id": tid,
+                "inserted": counts["inserted"],
+                "updated": counts["updated"],
+                "skipped": skipped,
+            }
+            tenant_summaries.append(summary)
+            logger.info("FX rate upsert for tenant %s: %s", tenant_row.id, summary)
 
         result = {"date": rate_date, "tenants": tenant_summaries}
         logger.info("FX rate upsert complete: %d tenants processed", len(tenant_summaries))


### PR DESCRIPTION
Closes #28 - Replace per-tenant per-currency individual SQL upserts with a bulk approach using a temp staging table and cross-join. Reduces query count from O(tenants x currencies) to O(1).