### PR TITLE
Handle parentheses-style negatives in decimal validation

### DIFF
--- a/jobs/src/jobs/inserters/holdings_inserter.py
+++ b/jobs/src/jobs/inserters/holdings_inserter.py
@@ -102,7 +102,12 @@ def _convert_value(raw, mapping: ColumnMapping, holdings_col: str):
     """Convert a raw string value to the appropriate Python type."""
     if mapping.data_type == "decimal":
         try:
-            return Decimal(str(raw).strip())
+            val = str(raw).strip()
+            # Handle parentheses-style negatives: (500.00) → -500.00
+            if val.startswith("(") and val.endswith(")"):
+                val = "-" + val[1:-1].strip()
+            val = val.replace(",", "")
+            return Decimal(val)
         except (InvalidOperation, ValueError):
             return None
 

--- a/jobs/src/jobs/validators/decimal_validator.py
+++ b/jobs/src/jobs/validators/decimal_validator.py
@@ -1,12 +1,31 @@
 """Validator: checks that decimal columns contain valid numbers."""
 
+import re
+
 import pandas as pd
 
 from src.jobs.validators.base import BaseValidator, ValidationContext
 
+# Matches values wrapped in parentheses, e.g. "(500.00)" or "( 1,234.56 )"
+_PARENS_RE = re.compile(r"^\((.+)\)$")
+
+
+def _normalise_decimal(val: str) -> str:
+    """Convert financial-format decimals to standard numeric strings.
+
+    Handles:
+    - Parentheses-style negatives: ``(500.00)`` → ``-500.00``
+    - Thousands-separator commas: ``1,234.56`` → ``1234.56``
+    """
+    val = val.strip()
+    m = _PARENS_RE.match(val)
+    if m:
+        val = "-" + m.group(1).strip()
+    val = val.replace(",", "")
+    return val
+
 
 class DecimalValidator(BaseValidator):
-
     def validate(self, df: pd.DataFrame, ctx: ValidationContext) -> pd.DataFrame:
         for col_def in ctx.column_defs:
             mapping = ctx.column_mappings.get(col_def.column_mapping)
@@ -18,6 +37,11 @@ class DecimalValidator(BaseValidator):
                 continue
 
             non_null = df[col].notna() & (df[col].astype(str).str.strip() != "")
+
+            # Normalise financial formats (parentheses negatives, commas)
+            # in-place so downstream steps (inserter) also see clean values.
+            df.loc[non_null, col] = df.loc[non_null, col].astype(str).map(_normalise_decimal)
+
             parsed = pd.to_numeric(df.loc[non_null, col], errors="coerce")
             bad = non_null & parsed.isna().reindex(df.index, fill_value=False)
 


### PR DESCRIPTION
Closes #27 - Add normalisation for parentheses-style negatives and comma separators in decimal columns