### PR TITLE
Add numeric string normalizer for decimal columns

### DIFF
--- a/jobs/src/jobs/file_processor.py
+++ b/jobs/src/jobs/file_processor.py
@@ -20,6 +20,7 @@ from src.jobs.helpers.file_loader import load_to_dataframe
 from src.jobs.helpers.status_writer import insert_status
 from src.jobs.inserters.holdings_inserter import insert_holdings
 from src.jobs.resolvers.fk_resolver import resolve_foreign_keys
+from src.jobs.transformers import normalize_numeric_columns
 from src.jobs.validators import (
     ColumnDef,
     ValidationContext,
@@ -120,6 +121,9 @@ def process_file_import(file_import_id: str, file_content: str, file_type: str) 
         col_defs = fetch_column_definitions(session, record["file_id"], record["tenant_id"])
         if not col_defs:
             raise ValueError("No column definitions found for this file")
+
+        # ── 2b. normalise numeric strings (strip commas, currency symbols)
+        df = normalize_numeric_columns(df, col_defs, COLUMN_MAPPINGS)
 
         # ── 3. run validation pipeline ──────────────────────────────────
         ctx = ValidationContext(

--- a/jobs/src/jobs/transformers/__init__.py
+++ b/jobs/src/jobs/transformers/__init__.py
@@ -1,0 +1,5 @@
+"""Data transformers — clean / normalise raw data before validation."""
+
+from src.jobs.transformers.numeric_normalizer import normalize_numeric_columns
+
+__all__ = ["normalize_numeric_columns"]

--- a/jobs/src/jobs/transformers/numeric_normalizer.py
+++ b/jobs/src/jobs/transformers/numeric_normalizer.py
@@ -1,0 +1,48 @@
+"""Transform step: normalise numeric strings before validation.
+
+Strips thousands-separator commas and common currency symbols from columns
+whose ``data_type`` is ``"decimal"`` so that downstream validators (which are
+read-only) see clean numeric values.
+"""
+
+import re
+
+import pandas as pd
+
+from src.column_mapper import ColumnMapping
+from src.jobs.validators.base import ColumnDef
+
+# Matches leading currency symbols (e.g. $, €, £, ¥) and thousands-separator commas.
+_CURRENCY_SYMBOLS = re.compile(r"[$€£¥]")
+
+
+def normalize_numeric_columns(
+    df: pd.DataFrame,
+    column_defs: list[ColumnDef],
+    column_mappings: dict[str, ColumnMapping],
+) -> pd.DataFrame:
+    """Strip commas and currency symbols from decimal columns **in-place**.
+
+    Only touches columns whose column_mapping has ``data_type == "decimal"``.
+    Non-string values and nulls are left untouched.
+    """
+    for col_def in column_defs:
+        mapping = column_mappings.get(col_def.column_mapping)
+        if mapping is None or mapping.data_type != "decimal":
+            continue
+
+        col = col_def.column_name
+        if col not in df.columns:
+            continue
+
+        series = df[col]
+        is_str = series.apply(lambda v: isinstance(v, str))
+        if not is_str.any():
+            continue
+
+        cleaned = series[is_str].str.replace(",", "", regex=False)
+        cleaned = cleaned.str.replace(_CURRENCY_SYMBOLS, "", regex=True)
+        cleaned = cleaned.str.strip()
+        df.loc[is_str, col] = cleaned
+
+    return df


### PR DESCRIPTION
Closes #26. Adds a transformers/numeric_normalizer.py module that strips thousands-separator commas and currency symbols from decimal columns before validation runs. Keeps validators read-only per the project architecture.