### PR TITLE
Default Portfolio View date to today

### DIFF
--- a/ui/src/components/PortfolioPositionReport.tsx
+++ b/ui/src/components/PortfolioPositionReport.tsx
@@ -2,8 +2,13 @@
 
 import { useState } from "react";
 
+function getTodayString(): string {
+  const d = new Date();
+  return d.toISOString().split("T")[0];
+}
+
 export default function PortfolioPositionReport() {
-  const [reportDate, setReportDate] = useState("");
+  const [reportDate, setReportDate] = useState(getTodayString);
   const [loading, setLoading] = useState(false);
   const [positions, setPositions] = useState<Record<string, unknown>[]>([]);
   const [summary, setSummary] = useState<{


### PR DESCRIPTION
Closes #21 - Initialize Portfolio View date input to today instead of empty string showing dd/mm/yyyy placeholder