### PR TITLE
Fix stale import_id reference between API and Celery worker

### DIFF
--- a/api/migrations/versions/d4e5f6a7b8c9_add_source_import_id_to_file_imports.py
+++ b/api/migrations/versions/d4e5f6a7b8c9_add_source_import_id_to_file_imports.py
@@ -1,0 +1,29 @@
+"""add source_import_id to file_imports
+
+Revision ID: d4e5f6a7b8c9
+Revises: c3d4e5f6a7b8
+Create Date: 2026-02-23 00:00:00.000000
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = "d4e5f6a7b8c9"
+down_revision: Union[str, None] = "c3d4e5f6a7b8"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column("file_imports", sa.Column("source_import_id", sa.UUID(), nullable=True))
+    op.create_index("ix_file_imports_source_import_id", "file_imports", ["source_import_id"])
+    # Backfill: set source_import_id = id for all existing rows
+    op.execute("UPDATE file_imports SET source_import_id = id WHERE source_import_id IS NULL")
+
+
+def downgrade() -> None:
+    op.drop_index("ix_file_imports_source_import_id", table_name="file_imports")
+    op.drop_column("file_imports", "source_import_id")

--- a/api/src/api/file_imports.py
+++ b/api/src/api/file_imports.py
@@ -2,7 +2,7 @@ import uuid
 
 from celery import Celery
 from fastapi import APIRouter, Depends, HTTPException, Query, UploadFile, File as FastAPIFile
-from sqlalchemy import desc, select
+from sqlalchemy import desc, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
@@ -32,18 +32,89 @@ async def list_file_imports(
     skip: int = Query(0, ge=0),
     limit: int = Query(100, ge=1, le=1000),
     status: str | None = Query(None),
+    latest_only: bool = Query(
+        False, description="Return only the latest status row per file upload"
+    ),
     session: AsyncSession = Depends(get_async_session),
     user: User = Depends(current_active_user),
 ):
-    query = select(FileImport).options(selectinload(FileImport.imported_by))
-    if not user.is_superuser:
-        query = query.where(FileImport.tenant_id == user.tenant_id)
-    if status:
-        query = query.where(FileImport.status == status)
+    if latest_only:
+        # Subquery: for each source_import_id group, find the max created_at.
+        # This gives us the latest audit-trail row per upload event.
+        latest_sub = (
+            select(func.max(FileImport.created_at).label("max_created"))
+            .where(FileImport.tenant_id == user.tenant_id)
+            .where(FileImport.source_import_id.is_not(None))
+            .group_by(FileImport.source_import_id)
+            .subquery()
+        )
+
+        query = (
+            select(FileImport)
+            .options(selectinload(FileImport.imported_by))
+            .where(FileImport.created_at.in_(select(latest_sub.c.max_created)))
+        )
+        if not user.is_superuser:
+            query = query.where(FileImport.tenant_id == user.tenant_id)
+        if status:
+            query = query.where(FileImport.status == status)
+    else:
+        query = select(FileImport).options(selectinload(FileImport.imported_by))
+        if not user.is_superuser:
+            query = query.where(FileImport.tenant_id == user.tenant_id)
+        if status:
+            query = query.where(FileImport.status == status)
+
     query = query.order_by(desc(FileImport.created_at)).offset(skip).limit(limit)
     result = await session.execute(query)
     imports = result.scalars().all()
     return [_with_name(fi) for fi in imports]
+
+
+@router.get("/by-file/{file_id}/latest", response_model=FileImportSchema)
+async def get_latest_file_import_by_file(
+    file_id: int,
+    session: AsyncSession = Depends(get_async_session),
+    user: User = Depends(current_active_user),
+):
+    """Get the latest import status row for a given file configuration."""
+    query = (
+        select(FileImport)
+        .options(selectinload(FileImport.imported_by))
+        .where(FileImport.file_id == file_id)
+        .order_by(desc(FileImport.created_at))
+        .limit(1)
+    )
+    if not user.is_superuser:
+        query = query.where(FileImport.tenant_id == user.tenant_id)
+    result = await session.execute(query)
+    file_import = result.scalar_one_or_none()
+    if not file_import:
+        raise HTTPException(status_code=404, detail="No imports found for this file")
+    return _with_name(file_import)
+
+
+@router.get("/by-source/{source_import_id}/latest", response_model=FileImportSchema)
+async def get_latest_by_source(
+    source_import_id: uuid.UUID,
+    session: AsyncSession = Depends(get_async_session),
+    user: User = Depends(current_active_user),
+):
+    """Get the latest status row for a specific upload event (tracked by source_import_id)."""
+    query = (
+        select(FileImport)
+        .options(selectinload(FileImport.imported_by))
+        .where(FileImport.source_import_id == source_import_id)
+        .order_by(desc(FileImport.created_at))
+        .limit(1)
+    )
+    if not user.is_superuser:
+        query = query.where(FileImport.tenant_id == user.tenant_id)
+    result = await session.execute(query)
+    file_import = result.scalar_one_or_none()
+    if not file_import:
+        raise HTTPException(status_code=404, detail="File import not found")
+    return _with_name(file_import)
 
 
 @router.get("/{import_id}", response_model=FileImportSchema)
@@ -52,7 +123,11 @@ async def get_file_import(
     session: AsyncSession = Depends(get_async_session),
     user: User = Depends(current_active_user),
 ):
-    query = select(FileImport).options(selectinload(FileImport.imported_by)).where(FileImport.id == import_id)
+    query = (
+        select(FileImport)
+        .options(selectinload(FileImport.imported_by))
+        .where(FileImport.id == import_id)
+    )
     if not user.is_superuser:
         query = query.where(FileImport.tenant_id == user.tenant_id)
     result = await session.execute(query)
@@ -88,6 +163,7 @@ async def upload_file(
     file_import = FileImport(
         id=file_import_id,
         file_id=file_id,
+        source_import_id=file_import_id,
         import_type="manual",
         status="RECEIVED",
         file_name=file.filename,

--- a/api/src/models/file_import.py
+++ b/api/src/models/file_import.py
@@ -1,7 +1,16 @@
 import uuid
 from datetime import datetime
 
-from sqlalchemy import BigInteger, CheckConstraint, DateTime, ForeignKey, Integer, String, Text, func
+from sqlalchemy import (
+    BigInteger,
+    CheckConstraint,
+    DateTime,
+    ForeignKey,
+    Integer,
+    String,
+    Text,
+    func,
+)
 from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
@@ -11,17 +20,21 @@ from src.database import Base
 class FileImport(Base):
     __tablename__ = "file_imports"
 
-    id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
-    )
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     file_id: Mapped[int | None] = mapped_column(
         BigInteger, ForeignKey("files.id", ondelete="SET NULL"), nullable=True
+    )
+    source_import_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), nullable=True, index=True
     )
 
     import_type: Mapped[str] = mapped_column(String(20), nullable=False)
     status: Mapped[str] = mapped_column(
         String(20),
-        CheckConstraint("status IN ('RECEIVED', 'PROCESSING', 'PROCESSED', 'FAILED')", name="ck_file_imports_status"),
+        CheckConstraint(
+            "status IN ('RECEIVED', 'PROCESSING', 'PROCESSED', 'FAILED')",
+            name="ck_file_imports_status",
+        ),
         nullable=False,
     )
 
@@ -32,12 +45,8 @@ class FileImport(Base):
     rows_processed: Mapped[int | None] = mapped_column(Integer, nullable=True)
     rows_failed: Mapped[int | None] = mapped_column(Integer, nullable=True)
 
-    started_at: Mapped[datetime | None] = mapped_column(
-        DateTime(timezone=True), nullable=True
-    )
-    completed_at: Mapped[datetime | None] = mapped_column(
-        DateTime(timezone=True), nullable=True
-    )
+    started_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    completed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     duration_seconds: Mapped[int | None] = mapped_column(Integer, nullable=True)
 
     error_message: Mapped[str | None] = mapped_column(Text, nullable=True)
@@ -50,9 +59,7 @@ class FileImport(Base):
         UUID(as_uuid=True), ForeignKey("tenants.id"), nullable=False
     )
 
-    created_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), server_default=func.now()
-    )
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
     updated_at: Mapped[datetime | None] = mapped_column(
         DateTime(timezone=True), onupdate=func.now()
     )

--- a/api/src/schemas/file_import.py
+++ b/api/src/schemas/file_import.py
@@ -29,6 +29,7 @@ class FileImportUpdate(BaseModel):
 class FileImportSchema(FileImportBase):
     id: uuid.UUID
     file_id: int | None = None
+    source_import_id: uuid.UUID | None = None
     rows_processed: int | None = None
     rows_failed: int | None = None
     started_at: datetime | None = None

--- a/jobs/src/jobs/file_processor.py
+++ b/jobs/src/jobs/file_processor.py
@@ -96,8 +96,8 @@ def process_file_import(file_import_id: str, file_content: str, file_type: str) 
         # ── fetch the original RECEIVED record ──────────────────────────
         result = session.execute(
             text("""
-                SELECT id, file_id, tenant_id, file_name, file_size,
-                       imported_by_user_id, import_type
+                SELECT id, file_id, source_import_id, tenant_id, file_name,
+                       file_size, imported_by_user_id, import_type
                 FROM file_imports
                 WHERE id = :fid
             """),

--- a/jobs/src/jobs/helpers/status_writer.py
+++ b/jobs/src/jobs/helpers/status_writer.py
@@ -12,9 +12,15 @@ def insert_status(session: Session, record: dict, status: str, **extra) -> str:
     new_id = str(uuid.uuid4())
     now = datetime.now(timezone.utc)
 
+    # source_import_id links all audit-trail rows back to the original RECEIVED row.
+    # If the record already has source_import_id, use it; otherwise fall back to
+    # the record's own id (for backwards compatibility with pre-migration rows).
+    source_id = record.get("source_import_id") or record["id"]
+
     params = {
         "id": new_id,
         "file_id": record["file_id"],
+        "source_import_id": source_id,
         "tenant_id": record["tenant_id"],
         "file_name": record["file_name"],
         "file_size": record["file_size"],
@@ -28,13 +34,13 @@ def insert_status(session: Session, record: dict, status: str, **extra) -> str:
     session.execute(
         text("""
             INSERT INTO file_imports
-                (id, file_id, tenant_id, file_name, file_size, imported_by_user_id,
-                 import_type, status, created_at,
+                (id, file_id, source_import_id, tenant_id, file_name, file_size,
+                 imported_by_user_id, import_type, status, created_at,
                  started_at, completed_at, rows_processed, rows_failed,
                  error_message, error_details)
             VALUES
-                (:id, :file_id, :tenant_id, :file_name, :file_size, :imported_by_user_id,
-                 :import_type, :status, :created_at,
+                (:id, :file_id, :source_import_id, :tenant_id, :file_name, :file_size,
+                 :imported_by_user_id, :import_type, :status, :created_at,
                  :started_at, :completed_at, :rows_processed, :rows_failed,
                  :error_message, CAST(:error_details AS jsonb))
         """),

--- a/ui/src/app/import-data/page.tsx
+++ b/ui/src/app/import-data/page.tsx
@@ -118,7 +118,7 @@ function ImportDataContent() {
   const loadImports = async () => {
     try {
       setImportsLoading(true);
-      const data = await fileImportApi.getImports(20);
+      const data = await fileImportApi.getImports(20, true);
       setImports(data);
     } catch {
       console.error("Error loading imports");

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -151,6 +151,7 @@ export const columnDefinitionApi = {
 export interface FileImportData {
   id: string;
   file_id: number | null;
+  source_import_id: string | null;
   import_type: string;
   status: string;
   file_name: string | null;
@@ -168,8 +169,16 @@ export interface FileImportData {
 }
 
 export const fileImportApi = {
-  getImports: async (limit = 20): Promise<FileImportData[]> => {
-    const response = await api.get("/file-imports/", { params: { limit } });
+  getImports: async (limit = 20, latestOnly = false): Promise<FileImportData[]> => {
+    const response = await api.get("/file-imports/", { params: { limit, latest_only: latestOnly } });
+    return response.data;
+  },
+  getLatestByFile: async (fileId: number): Promise<FileImportData> => {
+    const response = await api.get(`/file-imports/by-file/${fileId}/latest`);
+    return response.data;
+  },
+  getLatestBySource: async (sourceImportId: string): Promise<FileImportData> => {
+    const response = await api.get(`/file-imports/by-source/${sourceImportId}/latest`);
     return response.data;
   },
   uploadFile: async (


### PR DESCRIPTION
Closes #23 - Added source_import_id column to link audit trail rows back to original RECEIVED row, enabling reliable status tracking. Updated API with latest_only param and new lookup endpoints. Updated Celery worker and UI.