### PR TITLE
Safer way to authenticate

### DIFF
--- a/api/src/core/auth.py
+++ b/api/src/core/auth.py
@@ -4,7 +4,7 @@ from fastapi import Depends, Request
 from fastapi_users import BaseUserManager, FastAPIUsers, UUIDIDMixin
 from fastapi_users.authentication import (
     AuthenticationBackend,
-    BearerTransport,
+    CookieTransport,
     JWTStrategy,
 )
 
@@ -75,7 +75,13 @@ async def get_user_manager(user_db=Depends(get_user_db)):
     yield UserManager(user_db)
 
 
-bearer_transport = BearerTransport(tokenUrl="auth/jwt/login")
+cookie_transport = CookieTransport(
+    cookie_name="ohf_auth",
+    cookie_max_age=settings.access_token_lifetime_seconds,
+    cookie_httponly=True,
+    cookie_samesite="lax",
+    cookie_secure=False,  # Set True in production (HTTPS)
+)
 
 
 def get_jwt_strategy() -> JWTStrategy:
@@ -87,7 +93,7 @@ def get_jwt_strategy() -> JWTStrategy:
 
 auth_backend = AuthenticationBackend(
     name="jwt",
-    transport=bearer_transport,
+    transport=cookie_transport,
     get_strategy=get_jwt_strategy,
 )
 

--- a/api/src/defaults/__init__.py
+++ b/api/src/defaults/__init__.py
@@ -3,6 +3,7 @@ import uuid
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.defaults.asset_types import insert_default_asset_types_for_tenant
+from src.defaults.brokers import insert_default_brokers_for_tenant
 from src.defaults.continents import insert_default_continents_for_tenant
 from src.defaults.files import insert_default_files_for_tenant
 from src.defaults.countries import insert_default_countries_for_tenant
@@ -21,6 +22,7 @@ async def insert_defaults_for_tenant(session: AsyncSession, tenant_id: uuid.UUID
     since subtypes reference types via FK.
     """
     await insert_default_asset_types_for_tenant(session, tenant_id)
+    await insert_default_brokers_for_tenant(session, tenant_id)
     await insert_default_continents_for_tenant(session, tenant_id)
     await insert_default_countries_for_tenant(session, tenant_id)
     await insert_default_currencies_for_tenant(session, tenant_id)

--- a/api/src/defaults/brokers.py
+++ b/api/src/defaults/brokers.py
@@ -1,0 +1,29 @@
+import uuid
+
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+# Default brokers available to every tenant
+DEFAULT_BROKERS = [
+    ("JPM", "JP Morgan"),
+    ("CITI", "Citibank"),
+]
+
+
+async def insert_default_brokers_for_tenant(session: AsyncSession, tenant_id: uuid.UUID) -> int:
+    inserted = 0
+    for code, desc in DEFAULT_BROKERS:
+        result = await session.execute(
+            text("SELECT COUNT(*) FROM brokers WHERE broker_code = :code AND tenant_id = :tid"),
+            {"code": code, "tid": tenant_id},
+        )
+        if result.scalar() == 0:
+            await session.execute(
+                text("""
+                    INSERT INTO brokers (broker_code, broker_description, tenant_id, created_at)
+                    VALUES (:code, :desc, :tid, NOW())
+                """),
+                {"code": code, "desc": desc, "tid": tenant_id},
+            )
+            inserted += 1
+    return inserted

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -9,13 +9,11 @@
       "version": "0.1.0",
       "dependencies": {
         "axios": "^1.7.0",
-        "js-cookie": "^3.0.0",
         "next": "^15.0.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0"
       },
       "devDependencies": {
-        "@types/js-cookie": "^3.0.0",
         "@types/node": "^22.0.0",
         "@types/react": "^19.0.0",
         "eslint": "^9.0.0",
@@ -2049,13 +2047,6 @@
       "dependencies": {
         "@types/istanbul-lib-report": "*"
       }
-    },
-    "node_modules/@types/js-cookie": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/@types/js-cookie/-/js-cookie-3.0.6.tgz",
-      "integrity": "sha512-wkw9yd1kEXOPnvEeEV1Go1MmxtBJL0RR79aOTAApecWFVu7w0NNXNqhcWgvw2YgZDYadliXkl14pa3WXw5jlCQ==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
@@ -6183,15 +6174,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/supports-color?sponsor=1"
-      }
-    },
-    "node_modules/js-cookie": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.5.tgz",
-      "integrity": "sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=14"
       }
     },
     "node_modules/js-tokens": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -12,13 +12,11 @@
   },
   "dependencies": {
     "axios": "^1.7.0",
-    "js-cookie": "^3.0.0",
     "next": "^15.0.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },
   "devDependencies": {
-    "@types/js-cookie": "^3.0.0",
     "@types/node": "^22.0.0",
     "@types/react": "^19.0.0",
     "eslint": "^9.0.0",

--- a/ui/src/app/security-master/page.tsx
+++ b/ui/src/app/security-master/page.tsx
@@ -514,7 +514,7 @@ function DetailPanel({
                       coupon: null, maturity_date: null, issue_date: null,
                       first_coupon_date: null, penultimate_coupon_date: null, last_update_date: null,
                       ccy_id: null, country_id: null, security_subtype_id: null,
-                      asset_type_id: null, market_category_id: null,
+                      asset_type_id: null, sector_id: null, market_category_id: null,
                       tenant_id: "", created_at: "", updated_at: null,
                     };
                     const createTabProps: TabProps = { security: dummySecurity, lookups, ref: refData, editing: true, form, setForm };

--- a/ui/src/app/settings/brokers/page.tsx
+++ b/ui/src/app/settings/brokers/page.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect } from "react";
 import ProtectedRoute from "@/components/ProtectedRoute";
 import DashboardLayout from "@/components/DashboardLayout";
-import { brokerApi, BrokerData } from "@/lib/api";
+import { brokerApi, BrokerData, BrokerCreateData } from "@/lib/api";
 
 function EditIcon({ size = 16 }: { size?: number }) {
   return (<svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7" /><path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z" /></svg>);
@@ -58,7 +58,7 @@ function BrokersContent() {
   async function handleCreate(data: Partial<BrokerData>) {
     try {
       setError("");
-      await brokerApi.create(data);
+      await brokerApi.create(data as BrokerCreateData);
       await loadItems();
       setIsCreateModalOpen(false);
     } catch (err: any) {

--- a/ui/src/context/AuthContext.tsx
+++ b/ui/src/context/AuthContext.tsx
@@ -7,7 +7,6 @@ import {
   useEffect,
   useState,
 } from "react";
-import Cookies from "js-cookie";
 import api from "@/lib/api";
 
 interface User {
@@ -44,17 +43,10 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   const [loading, setLoading] = useState(true);
 
   const fetchUser = useCallback(async () => {
-    const token = Cookies.get("access_token");
-    if (!token) {
-      setUser(null);
-      setLoading(false);
-      return;
-    }
     try {
       const response = await api.get("/users/me");
       setUser(response.data);
     } catch {
-      Cookies.remove("access_token");
       setUser(null);
     } finally {
       setLoading(false);
@@ -70,11 +62,8 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     const params = new URLSearchParams();
     params.append("username", email);
     params.append("password", password);
-    const response = await api.post("/auth/jwt/login", params, {
+    await api.post("/auth/jwt/login", params, {
       headers: { "Content-Type": "application/x-www-form-urlencoded" },
-    });
-    Cookies.set("access_token", response.data.access_token, {
-      sameSite: "Lax",
     });
     await fetchUser();
   };
@@ -97,8 +86,12 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     await login(email, password);
   };
 
-  const logout = () => {
-    Cookies.remove("access_token");
+  const logout = async () => {
+    try {
+      await api.post("/auth/jwt/logout");
+    } catch {
+      // Ignore errors — cookie may already be expired
+    }
     setUser(null);
     window.location.href = "/login";
   };

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -1,26 +1,17 @@
 import axios from "axios";
-import Cookies from "js-cookie";
 
 const api = axios.create({
   baseURL: process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000",
   headers: {
     "Content-Type": "application/json",
   },
-});
-
-api.interceptors.request.use((config) => {
-  const token = Cookies.get("access_token");
-  if (token) {
-    config.headers.Authorization = `Bearer ${token}`;
-  }
-  return config;
+  withCredentials: true,
 });
 
 api.interceptors.response.use(
   (response) => response,
   (error) => {
     if (error.response?.status === 401) {
-      Cookies.remove("access_token");
       if (typeof window !== "undefined" && window.location.pathname !== "/login") {
         window.location.href = "/login";
       }


### PR DESCRIPTION
  1. api/src/core/auth.py — Switched from BearerTransport to CookieTransport
    - Cookie name: ohf_auth
    - httpOnly: true — JavaScript cannot read it
    - sameSite: lax — prevents CSRF on cross-origin
    - secure: false for local dev (set true for production/HTTPS)
  2. ui/src/lib/api.ts — Removed js-cookie import, removed the request interceptor that manually set Authorization
  headers. Added withCredentials: true so the browser automatically sends the cookie.
  3. ui/src/context/AuthContext.tsx — Removed all Cookies.get/set/remove calls. Login just calls the endpoint (server
  sets the cookie). Logout calls POST /auth/jwt/logout (server clears the cookie).
  4. ui/package.json — Removed js-cookie and @types/js-cookie

  How it works now: The server sets/clears an httpOnly cookie — JavaScript never touches the token. The browser handles
  it automatically.